### PR TITLE
ImportMessages handle empty array for messages

### DIFF
--- a/resources/js/components/import/ImportMessages.vue
+++ b/resources/js/components/import/ImportMessages.vue
@@ -62,19 +62,19 @@
         name: "ImportMessages",
         props: {
             messages: {
-                type: Object,
+                type: [Array, Object],
                 default: function () {
                     return {};
                 }
             },
             warnings: {
-                type: Object,
+                type: [Array, Object],
                 default: function () {
                     return {};
                 }
             },
             errors: {
-                type: Object,
+                type: [Array, Object],
                 default: function () {
                     return {};
                 }
@@ -82,10 +82,7 @@
         },
         methods: {
             isEmpty(obj) {
-                for (let x in obj) {
-                    return false;
-                }
-                return true;
+                return _.isEmpty(obj);
             }
         }
     }


### PR DESCRIPTION
ImportStatus provides an empty Array or an Object with line related messages list.

I received a lot of "Invalid prop: type check failed for prop "warnings". Expected Object, got Array"