### PR TITLE
Rewinds the iterator.

### DIFF
--- a/app/Services/Import/Task/Accounts.php
+++ b/app/Services/Import/Task/Accounts.php
@@ -177,6 +177,7 @@ class Accounts extends AbstractTask
             }
             Log::debug('No exact match found, return the first one.');
 
+            $response->rewind();
             /** @var Account $account */
             $account = $response->current();
             Log::debug(sprintf('Found %s account #%d based on "%s" "%s"', $account->type, $account->id, $field, $value));


### PR DESCRIPTION
Hi,

Thanks for this great software!

I have encountered an error when partial account matches are returned from the API. In this case, the code is supposed to use the first match but fails to do so.
 
The reason is that the `$response->current()` returns `null` because the iterator is in the wrong position.

This PR rewinds the iterator to the iterator to the first element.

@JC5