### PR TITLE
Respect MAIL_DESTINATION configuration option.

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -109,7 +109,7 @@ return [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
         'name'    => env('MAIL_FROM_NAME', 'Firefly III CSV Importer'),
     ],
-    'destination'        => env('YOUR_OWN_EMAIL@example.com', 'badly_configured@example.com'),
+    'destination'        => env('MAIL_DESTINATION', 'badly_configured@example.com'),
     'enable_mail_report' => env('ENABLE_MAIL_REPORT', false),
 
     /*


### PR DESCRIPTION
The MAIL_DESTINATION configuration option is not properly respected, which leads to undeliverable email reports.

By this patch the address configured in MAIL_DESTINATION is used. The default remains 'badly_configured@example.com'.

@JC5
