### PR TITLE
Added 'S' debit identifier for German Volksbank

### DIFF
--- a/app/Services/CSV/Converter/BankDebitCredit.php
+++ b/app/Services/CSV/Converter/BankDebitCredit.php
@@ -51,6 +51,7 @@ class BankDebitCredit implements ConverterInterface
             'Af', // ING (NL).
             'Debet', // Triodos (NL)
             'Debit', // ING (EN), thx Quibus!
+            'S', // Volksbank (DE), Short for "Soll"
         ];
         if (in_array(trim($value), $negative, true)) {
             return -1;


### PR DESCRIPTION
Relates to Pull Request #59 on firefly-iii/import-configurations

Changes in this pull request:

- added 'S' as a new debit identifier for the BankDebitCredit converter

@JC5
