### PR TITLE
add optional locale to date format

### DIFF
--- a/app/Http/Controllers/Import/ConfigurationController.php
+++ b/app/Http/Controllers/Import/ConfigurationController.php
@@ -140,11 +140,10 @@ class ConfigurationController extends Controller
     public function phpDate(Request $request): JsonResponse
     {
         Log::debug(sprintf('Now at %s', __METHOD__));
-        $format = $request->get('format');
-        $date   = Carbon::make('1984-09-17');
+        list($locale, $format) = \App\Services\CSV\Converter\Date::splitLocaleFormat($request->get('format'));
+        $date   = Carbon::make('1984-09-17')->locale($locale);
 
-        /** @noinspection NullPointerExceptionInspection */
-        return response()->json(['result' => $date->format($format)]);
+        return response()->json(['result' => $date->translatedFormat($format)]);
     }
 
     /**

--- a/app/Http/Controllers/Import/ConfigurationController.php
+++ b/app/Http/Controllers/Import/ConfigurationController.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Middleware\ConfigComplete;
 use App\Http\Request\ConfigurationPostRequest;
 use App\Services\CSV\Configuration\Configuration;
+use App\Services\CSV\Converter\Date;
 use App\Services\CSV\Specifics\SpecificService;
 use App\Services\Session\Constants;
 use App\Services\Storage\StorageService;
@@ -140,7 +141,7 @@ class ConfigurationController extends Controller
     public function phpDate(Request $request): JsonResponse
     {
         Log::debug(sprintf('Now at %s', __METHOD__));
-        list($locale, $format) = \App\Services\CSV\Converter\Date::splitLocaleFormat($request->get('format'));
+        [$locale, $format] = Date::splitLocaleFormat($request->get('format'));
         $date   = Carbon::make('1984-09-17')->locale($locale);
 
         return response()->json(['result' => $date->translatedFormat($format)]);

--- a/app/Services/CSV/Converter/Date.php
+++ b/app/Services/CSV/Converter/Date.php
@@ -38,6 +38,7 @@ class Date implements ConverterInterface
 {
     private $dateFormat = 'Y-m-d';
     private $dateLocale = 'en';
+    public static $dateFormatPattern = '/(?:('. join("|", array_keys(Language::all())).')\:)?(.+)/';
 
     /**
      * Convert a value.
@@ -88,12 +89,12 @@ class Date implements ConverterInterface
 
     public static function splitLocaleFormat(string $format): array
     {
-        preg_match(DATE_FORMAT_PATTERN, $format, $dateFormatConfiguration);
-        if (empty($dateFormatConfiguration)) {
-            $dateLocale = 'en';
-            $dateFormat = 'Y-m-d';
-        } else {
-            $dateLocale = $dateFormatConfiguration[1] ?: 'en';
+        $dateLocale = 'en';
+        $dateFormat = 'Y-m-d';
+        $dateFormatConfiguration = [];
+        preg_match(self::$dateFormatPattern, $format, $dateFormatConfiguration);
+        if (3 == count($dateFormatConfiguration)) {
+            $dateLocale = $dateFormatConfiguration[1] ?: $dateLocale;
             $dateFormat = $dateFormatConfiguration[2];
         }
         return [$dateLocale, $dateFormat];


### PR DESCRIPTION
Changes in this pull request:

This PR allows people to add a locale for the date parsing using this notation `it:<format>`.
I used the Carbon\Language::all() to parse the language code.
The changes are back-compatible.

@JC5
