### PR TITLE
Add verify config option to oauth request

### DIFF
--- a/app/Http/Controllers/TokenController.php
+++ b/app/Http/Controllers/TokenController.php
@@ -204,7 +204,7 @@ class TokenController extends Controller
         Log::debug(sprintf('Will contact "%s" for a token.', $finalURL));
 
 
-        $response = (new Client)->post($finalURL, $params);
+        $response = (new Client(['verify' => config('csv_importer.connection.verify')]))->post($finalURL, $params);
         try {
             $data = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {


### PR DESCRIPTION
Fixes issue #4183 
https://github.com/firefly-iii/firefly-iii/issues/4183

Changes in this pull request:

- The request in the TokenController::callback did not check the verify option in the config.
- 
- 

@JC5
